### PR TITLE
fix: add a nullish check to address no parent element issue

### DIFF
--- a/src/auro-menu.js
+++ b/src/auro-menu.js
@@ -49,7 +49,7 @@ class AuroMenu extends LitElement {
   }
 
   handleSlotChange() {
-    const parentIndexSelectedOption = Number(this.parentElement.getAttribute('indexSelectedOption'));
+    const parentIndexSelectedOption = parseInt(this.parentElement?.getAttribute('indexSelectedOption'), 10);
 
     // auro-menu is the child of a parent with an indexSelectedOption attribute
     if (!this.indexSelectedOption) {


### PR DESCRIPTION
# Alaska Airlines Pull Request

This fixes an issue where consumers of the component needed to set a parent element such as a div around auro-menu so that the this.parentElement reference in auro-menu.js did not throw an error. Consumers of the web component will no longer be required to wrap the component in a parent element. 

**Fixes:** #8 

## Summary:

This is a tiny change that fixes an issue where an error is thrown if the component does not have a parent element in the DOM.

## Type of change:

Please delete options that are not relevant.

- [x] Revision of an existing capability


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update