### PR TITLE
Fix: handle slot change updates index on dynamic updates to options #11

### DIFF
--- a/demo/demo.md
+++ b/demo/demo.md
@@ -44,7 +44,6 @@ To simulate the showing and hiding or `auro-menu` when it is used with `auro-dro
 
   ```html
   <auro-menu id="auroMenu0" indexSelectedOption="5" ishidden>
-  <auro-menu id="auroMenu0" indexSelectedOption="5" ishidden>
     <auro-menu-option slot="listOfOptions" data-value="the value for option 0">
       <span class="specialOption"><auro-icon category="interface" name="location-stroke" accent></auro-icon>Use my current location</span>
     </auro-menu-option>

--- a/src/auro-menu.js
+++ b/src/auro-menu.js
@@ -3,14 +3,12 @@
 
 // ---------------------------------------------------------------------
 
+import { LitElement, html, css } from "lit-element";
+import styleCss from "./style-css.js";
 import "@alaskaairux/auro-icon";
 import './auro-menu-option';
-
-import { LitElement, html, css } from "lit-element";
-
 // Import touch detection lib
 import "focus-visible/dist/focus-visible.min.js";
-import styleCss from "./style-css.js";
 
 // See https://git.io/JJ6SJ for "How to document your components using JSDoc"
 /**
@@ -44,7 +42,7 @@ class AuroMenu extends LitElement {
     `;
   }
 
-  firstUpdated() {
+  handleSlotChange() {
     const parentIndexSelectedOption = parseInt(this.parentElement.getAttribute('indexSelectedOption'), 10);
     
     // auro-menu is the child of a parent with an indexSelectedOption attribute
@@ -95,6 +93,7 @@ class AuroMenu extends LitElement {
     const funcFocus = (evt) => {
       evt.setAttribute('hasfocus', '')
     }
+
     const funcBlur = (evt) => {
       evt.removeAttribute('hasfocus')
     }
@@ -102,6 +101,7 @@ class AuroMenu extends LitElement {
     const funcMouseOver = (evt) => {
       evt.setAttribute('beingMouseOvered', '')
     }
+
     const funcMouseOut = (evt) => {
       evt.removeAttribute('beingMouseOvered')
     }
@@ -144,7 +144,6 @@ class AuroMenu extends LitElement {
       this.options[i].setAttribute('tabindex', '0');
       this.options[i].addEventListener('keydown', (evt) => handleKeyDown(evt));
       this.options[i].addEventListener('click', (evt) => dispatchEventOptionSelected(evt.target));
-
       this.options[i].addEventListener('focus', (evt) => funcFocus(evt.target));
       this.options[i].addEventListener('blur', (evt) => funcBlur(evt.target));
       this.options[i].addEventListener('mouseover', (evt) => funcMouseOver(evt.target));
@@ -152,25 +151,25 @@ class AuroMenu extends LitElement {
     }
   }
 
-attributeChangedCallback(name, oldVal, newVal) {
-  if (name.toLowerCase() === 'ishidden' && this.options) {
-    if (newVal === null) {
-      for (let i = 0; i < this.options.length; i++) {
-        this.options[i].setAttribute('tabindex', 0);
-      }
-    } else {
-      for (let i = 0; i < this.options.length; i++) {
-        this.options[i].setAttribute('tabindex', -1);
-      }    }
-  }
+  attributeChangedCallback(name, oldVal, newVal) {
+    if (name.toLowerCase() === 'ishidden' && this.options) {
+      if (newVal === null) {
+        for (let i = 0; i < this.options.length; i++) {
+          this.options[i].setAttribute('tabindex', 0);
+        }
+      } else {
+        for (let i = 0; i < this.options.length; i++) {
+          this.options[i].setAttribute('tabindex', -1);
+        }    }
+    }
 
-  super.attributeChangedCallback(name, oldVal, newVal);
-}
+    super.attributeChangedCallback(name, oldVal, newVal);
+  }
 
   render() {
     return html`
       <ul>
-        <slot name="listOfOptions"></slot>
+        <slot @slotchange=${this.handleSlotChange} name="listOfOptions"></slot>
       </ul>
     `;
   }


### PR DESCRIPTION
# Alaska Airlines Pull Request

Fixes an issue caused by only binding events on firstUpdated

**Fixes:** #11 

## Summary:

Options that are added programmatically should now have dispatch the change event which selects the option.

## Type of change:

- [x] New capability
- [x] Revision of an existing capability
