### PR TITLE
feat(preselect): add new selectByValue public method #118

### DIFF
--- a/demo/demo.md
+++ b/demo/demo.md
@@ -75,14 +75,14 @@ The `auro-menu` component supports the use of the `matchWord` attribute to highl
   ```js
   let matchWordInput;
   let matchWordMenu;
-
+  
   function matchWords() {
     matchWordInput = document.querySelector('#matchWordInput');
     matchWordMenu = document.querySelector('#matchWordMenu');
-
+  
     matchWordInput.addEventListener('keyup', updateMatch);
   }
-
+  
   function updateMatch() {
     matchWordMenu.matchWord = matchWordInput.value;
   }

--- a/docs/api.md
+++ b/docs/api.md
@@ -16,13 +16,15 @@ The auro-menu element provides users a way to select from a list of options.
 |----------------------|---------------------------------|--------------------------------------------------|
 | `makeSelection`      | `(): void`                      | Process actions for making making a menuoption selection. |
 | `resetOptionsStates` | `(): void`                      | Reset the menu and all options.                  |
+| `selectByValue`      | `(value: string): void`         | Method to apply `selected` attribute to `menuoption` via `value`.<br /><br />**value**: Must match a unique `menuoption` value. |
 | `selectNextItem`     | `(moveDirection: string): void` | Using value of current this.index evaluates index<br />of next :focus to set based on array of this.items ignoring items<br />with disabled attr.<br /><br />The event.target is not used as the function needs to know where to go,<br />versus knowing where it is.<br /><br />**moveDirection**: Up or Down based on keyboard event. |
 
 ## Events
 
-| Event            | Type               | Description                     |
-|------------------|--------------------|---------------------------------|
-| `selectedOption` | `CustomEvent<any>` | Value for selected menu option. |
+| Event                        | Type               | Description                                      |
+|------------------------------|--------------------|--------------------------------------------------|
+| `auroMenuSelectValueFailure` | `CustomEvent<any>` | Notifies that a an attempt to select a menuoption by matching a value has failed. |
+| `selectedOption`             | `CustomEvent<any>` | Notifies that a new menuoption selection has been made. |
 
 ## Slots
 

--- a/src/auro-menu.js
+++ b/src/auro-menu.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-magic-numbers */
+/* eslint-disable no-magic-numbers, max-lines */
 // Copyright (c) 2021 Alaska Airlines. All right reserved. Licensed under the Apache-2.0 license
 // See LICENSE in the project root for license information.
 
@@ -16,7 +16,8 @@ import "mark.js/dist/mark.min";
  * @attr {String} value - Specifies the value to be sent to a server.
  * @attr {Object} optionSelected - Specifies the current selected menuOption.
  * @attr {String} matchWord - Specifies the a string used to highlight matched string parts in options.
- * @fires selectedOption - Value for selected menu option.
+ * @fires selectedOption - Notifies that a new menuoption selection has been made.
+ * @fires auroMenuSelectValueFailure - Notifies that a an attempt to select a menuoption by matching a value has failed.
  * @slot Slot for insertion of menu options.
  */
 
@@ -240,6 +241,30 @@ class AuroMenu extends LitElement {
 
       this.handleNestedMenus(nestedMenu);
     });
+  }
+
+  /**
+   * Method to apply `selected` attribute to `menuoption` via `value`.
+   * @param {String} value - Must match a unique `menuoption` value.
+   */
+  selectByValue(value) {
+    let valueMatch = false;
+
+    for (let index = 0; index < this.items.length; index += 1) {
+      if (this.items[index].value === value) {
+        valueMatch = true;
+        this.index = index;
+        this.makeSelection();
+      }
+    }
+
+    if (!valueMatch) {
+      this.dispatchEvent(new CustomEvent('auroMenuSelectValueFailure', {
+        bubbles: true,
+        cancelable: false,
+        composed: true,
+      }));
+    }
   }
 
   /**


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

**Fixes:** #118

## Summary:

This change adds the `selectByValue(value)` public method. This is useful for `auro-select` where the consumer wants to to directly set `<auro-select value="helloworld">....`

This work is aimed at resolving this ticket in `auro-select` https://github.com/AlaskaAirlines/auro-select/issues/60.

## Type of change:

Please delete options that are not relevant.

- [x] New capability
- [ ] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate)


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
