### PR TITLE
Make overflow menuoptions be accessible via scroll

### DIFF
--- a/demo/demo.md
+++ b/demo/demo.md
@@ -41,6 +41,91 @@ A default `auro-menu` element with nested `auro-menuoption` elements to generate
 
 </auro-accordion>
 
+## Scroll
+
+When setting the `max-height` of `auro-menu`, all of the overflowing content can be accessed via a scrollbar.
+
+<div class="exampleWrapper">
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=./partials/scroll.html) -->
+  <!-- The below content is automatically added from ./partials/scroll.html -->
+  <auro-menu id="alpha" style="max-height: 200px">
+    <auro-menuoption value="stops">Stops</auro-menuoption>
+    <auro-menuoption value="price">Price</auro-menuoption>
+    <auro-menuoption value="duration">Duration</auro-menuoption>
+    <hr>
+    <auro-menu id="beta">
+      <auro-menuoption value="apples">Apples</auro-menuoption>
+      <auro-menuoption value="oranges">Oranges</auro-menuoption>
+      <auro-menuoption value="pears">Pears</auro-menuoption>
+      <auro-menuoption value="grapes">Grapes</auro-menuoption>
+      <auro-menuoption value="kiwi">Kiwi</auro-menuoption>
+      <hr>
+      <auro-menu id="charlie">
+        <auro-menuoption value="person">Person</auro-menuoption>
+        <auro-menuoption value="woman">Woman</auro-menuoption>
+        <auro-menuoption value="man">Man</auro-menuoption>
+        <auro-menuoption value="camera">Camera</auro-menuoption>
+        <auro-menuoption value="tv">TV</auro-menuoption>
+      </auro-menu>
+    </auro-menu>
+    <hr>
+    <auro-menuoption value="departure">Departure</auro-menuoption>
+    <auro-menuoption value="arrival">Arrival</auro-menuoption>
+    <hr>
+    <auro-menu id="delta">
+      <auro-menuoption value="cars">Cars</auro-menuoption>
+      <auro-menuoption value="trucks">Trucks</auro-menuoption>
+      <auro-menuoption value="boats">Boats</auro-menuoption>
+      <auro-menuoption value="planes">Planes</auro-menuoption>
+      <auro-menuoption value="motorcycles">Motorcycles</auro-menuoption>
+    </auro-menu>
+  </auro-menu>
+  <!-- AURO-GENERATED-CONTENT:END -->
+</div>
+
+<auro-accordion lowProfile justifyRight>
+  <span slot="trigger">See code</span>
+
+  <!-- AURO-GENERATED-CONTENT:START (CODE:src=./partials/scroll.html) -->
+  <!-- The below code snippet is automatically added from ./partials/scroll.html -->
+  ```html
+  <auro-menu id="alpha" style="max-height: 200px">
+    <auro-menuoption value="stops">Stops</auro-menuoption>
+    <auro-menuoption value="price">Price</auro-menuoption>
+    <auro-menuoption value="duration">Duration</auro-menuoption>
+    <hr>
+    <auro-menu id="beta">
+      <auro-menuoption value="apples">Apples</auro-menuoption>
+      <auro-menuoption value="oranges">Oranges</auro-menuoption>
+      <auro-menuoption value="pears">Pears</auro-menuoption>
+      <auro-menuoption value="grapes">Grapes</auro-menuoption>
+      <auro-menuoption value="kiwi">Kiwi</auro-menuoption>
+      <hr>
+      <auro-menu id="charlie">
+        <auro-menuoption value="person">Person</auro-menuoption>
+        <auro-menuoption value="woman">Woman</auro-menuoption>
+        <auro-menuoption value="man">Man</auro-menuoption>
+        <auro-menuoption value="camera">Camera</auro-menuoption>
+        <auro-menuoption value="tv">TV</auro-menuoption>
+      </auro-menu>
+    </auro-menu>
+    <hr>
+    <auro-menuoption value="departure">Departure</auro-menuoption>
+    <auro-menuoption value="arrival">Arrival</auro-menuoption>
+    <hr>
+    <auro-menu id="delta">
+      <auro-menuoption value="cars">Cars</auro-menuoption>
+      <auro-menuoption value="trucks">Trucks</auro-menuoption>
+      <auro-menuoption value="boats">Boats</auro-menuoption>
+      <auro-menuoption value="planes">Planes</auro-menuoption>
+      <auro-menuoption value="motorcycles">Motorcycles</auro-menuoption>
+    </auro-menu>
+  </auro-menu>
+  ```
+  <!-- AURO-GENERATED-CONTENT:END -->
+
+</auro-accordion>
+
 ## noCheckmark
 
 Applying the `noCheckmark` attribute will prevent the check icon from being shown on the selected option. The left padding to reserve space for the checkmark is also removed.

--- a/demo/partials/scroll.html
+++ b/demo/partials/scroll.html
@@ -1,0 +1,32 @@
+<auro-menu id="alpha" style="max-height: 200px">
+  <auro-menuoption value="stops">Stops</auro-menuoption>
+  <auro-menuoption value="price">Price</auro-menuoption>
+  <auro-menuoption value="duration">Duration</auro-menuoption>
+  <hr>
+  <auro-menu id="beta">
+    <auro-menuoption value="apples">Apples</auro-menuoption>
+    <auro-menuoption value="oranges">Oranges</auro-menuoption>
+    <auro-menuoption value="pears">Pears</auro-menuoption>
+    <auro-menuoption value="grapes">Grapes</auro-menuoption>
+    <auro-menuoption value="kiwi">Kiwi</auro-menuoption>
+    <hr>
+    <auro-menu id="charlie">
+      <auro-menuoption value="person">Person</auro-menuoption>
+      <auro-menuoption value="woman">Woman</auro-menuoption>
+      <auro-menuoption value="man">Man</auro-menuoption>
+      <auro-menuoption value="camera">Camera</auro-menuoption>
+      <auro-menuoption value="tv">TV</auro-menuoption>
+    </auro-menu>
+  </auro-menu>
+  <hr>
+  <auro-menuoption value="departure">Departure</auro-menuoption>
+  <auro-menuoption value="arrival">Arrival</auro-menuoption>
+  <hr>
+  <auro-menu id="delta">
+    <auro-menuoption value="cars">Cars</auro-menuoption>
+    <auro-menuoption value="trucks">Trucks</auro-menuoption>
+    <auro-menuoption value="boats">Boats</auro-menuoption>
+    <auro-menuoption value="planes">Planes</auro-menuoption>
+    <auro-menuoption value="motorcycles">Motorcycles</auro-menuoption>
+  </auro-menu>
+</auro-menu>

--- a/src/auro-menu.js
+++ b/src/auro-menu.js
@@ -425,31 +425,38 @@ class AuroMenu extends LitElement {
   }
 
   /**
+   * Used to only make a selection when a menuoption is receiving a mousedown event.
+   * @param {Event} evt - Mousedown event.
+   * @private
+   */
+  handleMenuMouseDown(evt) {
+    if (evt.target !== this) {
+      this.makeSelection();
+    }
+  }
+
+  /**
    * Used for @slotchange event on slotted element.
    * @private
    */
   handleSlotItems() {
-
-    /**
-     * Determine if this is the root of the menu/submenu layout.
-     */
+    // Determine if this is the root of the menu/submenu layout.
     if (this.parentElement && this.parentElement.closest('auro-menu')) {
       this.rootMenu = false;
     }
 
-    /**
-     * If this is the root menu (not a nested menu) handle events, states and styling.
-     */
+    // If this is the root menu (not a nested menu) handle events, states and styling.
     if (this.rootMenu) {
       this.initItems();
       this.setAttribute('role', 'listbox');
+      this.setAttribute('root', '');
       this.handleNestedMenus(this);
       this.markOptions();
       this.index = -1;
       this.getSelectedIndex();
 
       this.addEventListener('keydown', this.handleKeyDown);
-      this.addEventListener('mousedown', this.makeSelection);
+      this.addEventListener('mousedown', this.handleMenuMouseDown);
       this.addEventListener('auroMenuOption-mouseover', (evt) => {
         this.index = this.items.indexOf(evt.target);
         this.updateActiveOption(this.index);

--- a/src/style-base.scss
+++ b/src/style-base.scss
@@ -51,3 +51,7 @@
     padding-left: var(--auro-size-md);
   }
 }
+
+:host([root]) {
+  overflow-y: auto;
+}


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

**Fixes:** #159 

## Summary:

_Please summarize the scope of the changes you have submitted, what the intent of the work is and anything that describes the before/after state of the project._

Set `overflow-y: auto` on the root menu, so that when an implementer sets a `max-height` on `auro-menu`, the overflowing content will be accessible via scrollbar.

## Type of change:

Please delete options that are not relevant.

- [ ] New capability
- [x] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate)


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
