### PR TITLE
AURO MIGRATION: Update node to v22

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -70,7 +70,7 @@ branches:
         # Required. Require branches to be up to date before merging.
         strict: true
         # Required. The list of status checks to require in order to merge into this branch
-        contexts: ["test (18.x)", "test (20.x)", "license/cla"]
+        contexts: ["test (20.x)", "test (22.x)", "license/cla"]
       # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
       enforce_admins: false
       # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.

--- a/.github/workflows/testPublish.yml
+++ b/.github/workflows/testPublish.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 22.x]
 
     steps:
       - uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+node-version: 22.x
       - run: npm ci
       - run: npm run build:release
       - uses: cycjimmy/semantic-release-action@v4

--- a/.github/workflows/testPublish.yml
+++ b/.github/workflows/testPublish.yml
@@ -39,7 +39,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@v4
         with:
-node-version: 22.x
+          node-version: 22.x
       - run: npm ci
       - run: npm run build:release
       - uses: cycjimmy/semantic-release-action@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@alaskaairux/icons": "^4.44.1",
-        "@aurodesignsystem/auro-icon": "^6.0.2",
-        "@aurodesignsystem/auro-library": "^3.0.2",
+        "@aurodesignsystem/auro-icon": "^6.1.2",
+        "@aurodesignsystem/auro-library": "^3.0.3",
         "lit": "^3.2.1"
       },
       "devDependencies": {
@@ -146,18 +146,18 @@
       }
     },
     "node_modules/@aurodesignsystem/auro-icon": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-icon/-/auro-icon-6.0.2.tgz",
-      "integrity": "sha512-dzs5VfBiQHGdjKKbbSs4lu0jlqLusJNncJtr/Tq7P0kSV648JQ5OLpuuhP1xupcecF1Q3WFhsTVI5NyXmTIzhw==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-icon/-/auro-icon-6.1.2.tgz",
+      "integrity": "sha512-6bR6dxNoofgkwBz2q0NMAuO76DAhJrAqtndcP4Lt54hOIyLTmDD1CXAVmd4aB5h+DTG4WSgQeA7NMtVTufKmJA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aurodesignsystem/auro-library": "~2.8",
+        "@aurodesignsystem/auro-library": "^3.0.1",
         "chalk": "^5.3.0",
         "lit": "^3.2.1"
       },
       "engines": {
-        "node": "^18.x || ^20.x"
+        "node": "^20.x || ^22.x "
       },
       "peerDependencies": {
         "@alaskaairux/icons": "^4.43.0",
@@ -165,26 +165,10 @@
         "@aurodesignsystem/webcorestylesheets": "^5.1.2"
       }
     },
-    "node_modules/@aurodesignsystem/auro-icon/node_modules/@aurodesignsystem/auro-library": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-library/-/auro-library-2.8.0.tgz",
-      "integrity": "sha512-oTRTd05JE3BVVQC3P11jTDGmTKXCi/Yi6XtKTp8dZVC+euJLDsySjVctAplqmOD3JqqwbJgtbNdlK7DpGRuCXg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "markdown-magic": "^2.6.1",
-        "npm-run-all": "^4.1.5"
-      },
-      "bin": {
-        "generateDocs": "bin/generateDocs.mjs"
-      },
-      "engines": {
-        "node": "^18 || ^20"
-      }
-    },
     "node_modules/@aurodesignsystem/auro-library": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-library/-/auro-library-3.0.2.tgz",
-      "integrity": "sha512-U3DQf0ah6FcJCb4w/XIoKiemg1XPuQCAstQI0juFSAjUQ8Ix3SaJTPwdKomg6legGR+YTFmrNk+ZeJRYJ5aE0g==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-library/-/auro-library-3.0.3.tgz",
+      "integrity": "sha512-Vr+ICwv1u8QbwHin7/QxWZU9FmQYzWChIqKYqqUo+Z4hWOfJbeebYbyZjiqAANeluzodwUa5ocJ8gMm430A1fQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "handlebars": "^4.7.8",
@@ -195,7 +179,7 @@
         "generateDocs": "bin/generateDocs.mjs"
       },
       "engines": {
-        "node": "^18 || ^20"
+        "node": "^20.x || ^22.x"
       }
     },
     "node_modules/@aurodesignsystem/design-tokens": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aurodesignsystem/auro-menu",
-  "version": "4.1.4",
+  "version": "4.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aurodesignsystem/auro-menu",
-      "version": "4.1.4",
+      "version": "4.2.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -63,7 +63,7 @@
         "yaml-lint": "^1.7.0"
       },
       "engines": {
-        "node": "^18.x || ^20.x"
+        "node": "^20.x || ^22.x "
       },
       "peerDependencies": {
         "@aurodesignsystem/design-tokens": "^4.9.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "main": "index.js",
   "license": "Apache-2.0",
   "engines": {
-    "node": "^18.x || ^20.x"
+    "node": "^20.x || ^22.x "
   },
   "dependencies": {
     "@alaskaairux/icons": "^4.44.1",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   },
   "dependencies": {
     "@alaskaairux/icons": "^4.44.1",
-    "@aurodesignsystem/auro-icon": "^6.0.2",
-    "@aurodesignsystem/auro-library": "^3.0.2",
+    "@aurodesignsystem/auro-icon": "^6.1.2",
+    "@aurodesignsystem/auro-library": "^3.0.3",
     "lit": "^3.2.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
Resolves AlaskaAirlines/auro-templates#6

## Summary by Sourcery

Update Node.js to version 22.

Build:
- Update Node engine to support versions 20 and 22.

CI:
- Update CI workflow to test on Node versions 20 and 22.

Documentation:
- Update contributing guidelines with information about rebasing, conventional commits, and issue/PR templates.

Tests:
- Update test matrix to include Node version 22.